### PR TITLE
Fix error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "watch": "npm run build -- --watch"
   },
   "dependencies": {
+    "invariant": "^2.2.2",
     "sketchapp-json-flow-types": "^0.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",
-    "babel-preset-stage-3": "^6.22.0",
-    "babel-preset-es2015": "^6.22.0"
+    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-stage-3": "^6.22.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const invariant = require('invariant');
+import invariant from 'invariant';
 /*
 This is pretty simplistic at the moment, since it doesn't handle references. More work is needed to actually
 */

--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,12 @@
 This is pretty simplistic at the moment, since it doesn't handle references. More work is needed to actually
 */
 
-let envOK = (
-   MSJSONDataArchiver !== undefined
-&& MSJSONDictionaryUnarchiver !== undefined
-);
+let envOK =
+   (typeof MSJSONDataArchiver !== 'undefined')
+&& (typeof MSJSONDictionaryUnarchiver !== 'undefined')
 
 function appVersion() {
-  if (NSBundle !== undefined) {
+  if (typeof NSBundle !== 'undefined') {
     return NSBundle.mainBundle().infoDictionary().CFBundleShortVersionString;
   } else {
     return undefined;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-
+const invariant = require('invariant');
 /*
 This is pretty simplistic at the moment, since it doesn't handle references. More work is needed to actually
 */
@@ -15,11 +15,8 @@ function appVersion() {
   }
 }
 
-const _checkEnv = () => {
-  if (!envOK) {
-    throw new Error("sketchapp-json-plugin needs to run within the correct version of Sketch. You are running " + appVersion());
-  }
-}
+const _checkEnv = () =>
+  invariant(envOK, `sketchapp-json-plugin needs to run within the correct version of Sketch. You are running ${appVersion()}`);
 
 export function appVersionSupported() {
   return envOK;

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,7 +982,7 @@ ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
-invariant@^2.2.0:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:


### PR DESCRIPTION
`foo !== undefined` was breaking Sketch <43 - replaced it with `typeof foo !== 'undefined`, and added in invariant for consistency in error handling