### PR TITLE
Enable ability to read `resizingConstraint` and `changeIdentifier` from sketch JSON tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Additionally, if you would like to create layers from a dictionary, you want thi
     };
     fromSJSONObject(obj);
 
-If you want to support older versions of Sketch:
+If you want to guard against legacy versions of Sketch (v42 and under):
 
     import JSONPlugin from 'sketchapp-json-plugin';
     if (JSONPlugin.appVersionSupported()) {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Additionally, if you would like to create layers from a dictionary, you want thi
     };
     fromSJSONObject(obj);
 
-If you want to verify your versions of Sketch is compatible (v43+):
+If you want to verify your version of Sketch is compatible (v43+):
 
     import JSONPlugin from 'sketchapp-json-plugin';
     if (JSONPlugin.appVersionSupported()) {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Additionally, if you would like to create layers from a dictionary, you want thi
     };
     fromSJSONObject(obj);
 
-If you want to guard against legacy versions of Sketch (v42 and under):
+If you want to verify your versions of Sketch is compatible (v43+):
 
     import JSONPlugin from 'sketchapp-json-plugin';
     if (JSONPlugin.appVersionSupported()) {

--- a/src/index.js
+++ b/src/index.js
@@ -51,9 +51,9 @@ export function fromSJSON(json) {
 }
 
 // Takes a Sketch JSON tree and turns it into a native object. May throw on invalid data
-export function fromSJSONDictionary(jsonTree, version = SKETCH_LOWEST_COMPATIBLE_VERSION) {
+export function fromSJSONDictionary(jsonTree) {
   _checkEnv();
-  const decoded = MSJSONDictionaryUnarchiver.unarchiveObjectFromDictionary_asVersion_corruptionDetected_error(jsonTree, version, null, null);
+  const decoded = MSJSONDictionaryUnarchiver.unarchiveObjectFromDictionary_asVersion_corruptionDetected_error(jsonTree, SKETCH_LOWEST_COMPATIBLE_VERSION, null, null);
   const mutableClass = decoded.class().mutableClass();
   return mutableClass.alloc().initWithImmutableModelObject(decoded);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ export function fromSJSON(json) {
 // Takes a Sketch JSON tree and turns it into a native object. May throw on invalid data
 export function fromSJSONDictionary(jsonTree) {
   _checkEnv();
-  const decoded = MSJSONDictionaryUnarchiver.alloc().initForReadingFromDictionary(jsonTree).decodeRoot();
+  const decoded = MSJSONDictionaryUnarchiver.unarchiveObjectFromDictionary_asVersion_corruptionDetected_error(jsonTree,999,nil,nil);
   const mutableClass = decoded.class().mutableClass();
   return mutableClass.alloc().initWithImmutableModelObject(decoded);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,14 @@ import invariant from 'invariant';
 This is pretty simplistic at the moment, since it doesn't handle references. More work is needed to actually
 */
 
+/*
+Versions based on discussion info: http://sketchplugins.com/d/316-sketch-version
+*/
+// Internal Sketch Version (ex: 88 => v43+)
+const SKETCH_LOWEST_COMPATIBLE_VERSION = '88';
+// External Sketch Version
+const SKETCH_LOWEST_COMPATIBLE_APP_VERSION = '43';
+
 let envOK =
    (typeof MSJSONDataArchiver !== 'undefined')
 && (typeof MSJSONDictionaryUnarchiver !== 'undefined')
@@ -16,7 +24,7 @@ function appVersion() {
 }
 
 const _checkEnv = () =>
-  invariant(envOK, `sketchapp-json-plugin needs to run within the correct version of Sketch. You are running ${appVersion()}`);
+  invariant(envOK, `sketchapp-json-plugin needs to run within Sketch v${SKETCH_LOWEST_COMPATIBLE_APP_VERSION}+. You are running ${appVersion()}`);
 
 export function appVersionSupported() {
   return envOK;
@@ -43,9 +51,9 @@ export function fromSJSON(json) {
 }
 
 // Takes a Sketch JSON tree and turns it into a native object. May throw on invalid data
-export function fromSJSONDictionary(jsonTree) {
+export function fromSJSONDictionary(jsonTree, version = SKETCH_LOWEST_COMPATIBLE_VERSION) {
   _checkEnv();
-  const decoded = MSJSONDictionaryUnarchiver.unarchiveObjectFromDictionary_asVersion_corruptionDetected_error(jsonTree,999,nil,nil);
+  const decoded = MSJSONDictionaryUnarchiver.unarchiveObjectFromDictionary_asVersion_corruptionDetected_error(jsonTree, version, null, null);
   const mutableClass = decoded.class().mutableClass();
   return mutableClass.alloc().initWithImmutableModelObject(decoded);
 }


### PR DESCRIPTION
In order to support Sketch 44+ `resizingConstraint`, a different method needs to be used for creating a Sketch tree: `unarchiveObjectFromDictionary_asVersion_corruptionDetected_error `.

Notes:
- Will still work with Sketch v43+ (`resizingConstraint` & `changeIdentifier` properties within JSON will just be ignored)
- Will enable react-sketchapp to manipulate the `resizingConstraint` & `changeIdentifier` properties: https://github.com/airbnb/react-sketchapp/issues/150 & https://github.com/airbnb/react-sketchapp/issues/172

Discussion source for method: [Link](http://sketchplugins.com/d/223-msjsondataarchiver-not-serializing-new-sketch-44-resize-options)